### PR TITLE
Add VPC, security groups, and tags to Lambda module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.17 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | github.com/FPGSchiba/terraform-aws-lambda | v2.0.1 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | github.com/FPGSchiba/terraform-aws-lambda | v2.1.1 |
 
 ## Resources
 
@@ -60,7 +60,10 @@
 | <a name="input_path_name"></a> [path\_name](#input\_path\_name) | The resource Path used on the api. If this value is a Path Variable, please use the name\_overwrite variable. | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | The Prefix used to deploy the lambda function. | `string` | n/a | yes |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda Runtime | `string` | `"provided.al2"` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | List of security group rules to apply | <pre>list(object({<br/>    name        = string<br/>    description = string<br/>    ingress_rules = list(object({<br/>      type        = string<br/>      from_port   = optional(number)<br/>      to_port     = optional(number)<br/>      ip_protocol = string<br/>      cidr_block  = string<br/>    }))<br/>    egress_rules = list(object({<br/>      type        = string<br/>      from_port   = optional(number)<br/>      to_port     = optional(number)<br/>      ip_protocol = string<br/>      cidr_block  = string<br/>    }))<br/>  }))</pre> | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Number of seconds, until the Lambda timeouts | `number` | `3` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to deploy the lambda function in. If this value is null, the lambda function will be deployed outside of a VPC. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ module "lambda" {
   main_filename             = var.main_filename
   security_groups           = var.security_groups
   vpc_id                    = var.vpc_id
-  tags = var.tags
+  tags                      = var.tags
 }
 
 resource "aws_api_gateway_resource" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.0.1"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.1.1"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"
@@ -11,6 +11,9 @@ module "lambda" {
   timeout                   = var.timeout
   additional_iam_statements = var.additional_iam_statements
   main_filename             = var.main_filename
+  security_groups           = var.security_groups
+  vpc_id                    = var.vpc_id
+  tags = var.tags
 }
 
 resource "aws_api_gateway_resource" "this" {

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -62,12 +62,12 @@ resource "aws_api_gateway_deployment" "this" {
   ]
 }
 
-resource "aws_api_gateway_stage" "example" {
+resource "aws_api_gateway_stage" "this" {
   deployment_id = aws_api_gateway_deployment.this.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
   stage_name    = "test"
 }
 
 output "stage_url" {
-  value = aws_api_gateway_deployment.this.invoke_url
+  value = aws_api_gateway_stage.this.invoke_url
 }

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -55,12 +55,17 @@ module "microservice" {
 
 resource "aws_api_gateway_deployment" "this" {
   rest_api_id = aws_api_gateway_rest_api.api.id
-  stage_name  = "test"
 
   depends_on = [
     module.microservice,
     aws_api_gateway_rest_api.api
   ]
+}
+
+resource "aws_api_gateway_stage" "example" {
+  deployment_id = aws_api_gateway_deployment.this.id
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  stage_name    = "test"
 }
 
 output "stage_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -121,3 +121,47 @@ variable "name_overwrite" {
   type        = string
   default     = null
 }
+
+variable "security_groups" {
+  description = "List of security group rules to apply"
+  type = list(object({
+    name        = string
+    description = string
+    ingress_rules = list(object({
+      type        = string
+      from_port   = optional(number)
+      to_port     = optional(number)
+      ip_protocol = string
+      cidr_block  = string
+    }))
+    egress_rules = list(object({
+      type        = string
+      from_port   = optional(number)
+      to_port     = optional(number)
+      ip_protocol = string
+      cidr_block  = string
+    }))
+  }))
+  validation {
+    condition = alltrue([
+      for sg in var.security_groups : alltrue([
+        alltrue([for rule in sg.ingress_rules : contains(["ipv4", "ipv6"], rule.type)]),
+        alltrue([for rule in sg.egress_rules : contains(["ipv4", "ipv6"], rule.type)])
+      ])
+    ])
+    error_message = "Each rule.type must be either 'ipv4' or 'ipv6'."
+  }
+  default = []
+}
+
+variable "vpc_id" {
+  description = "The VPC ID to deploy the lambda function in. If this value is null, the lambda function will be deployed outside of a VPC."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Updated the Lambda module source to v2.1.1 and added support for specifying security groups, VPC ID, and resource tags via new variables. This enhances Lambda deployment flexibility and resource management.