### PR TITLE
Add go_build_tags variable to Lambda module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ module "lambda" {
   security_groups           = var.security_groups
   vpc_id                    = var.vpc_id
   tags                      = var.tags
+  go_build_tags             = var.go_build_tags
 }
 
 resource "aws_api_gateway_resource" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "go_build_tags" {
+  description = "Build tags for go build command"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Introduces a new 'go_build_tags' variable to allow specifying build tags for the Go build command in the Lambda module. Updates both main.tf and variables.tf to support this configuration.