### PR TITLE
Update Lambda module and add vpc_networked variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.1.3"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.1.4"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"
@@ -15,6 +15,7 @@ module "lambda" {
   vpc_id                    = var.vpc_id
   tags                      = var.tags
   go_build_tags             = var.go_build_tags
+  vpc_networked             = var.vpc_networked
 }
 
 resource "aws_api_gateway_resource" "this" {
@@ -138,5 +139,5 @@ resource "aws_lambda_permission" "this" {
   principal     = "apigateway.amazonaws.com"
 
   # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
-  source_arn = "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${data.aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.this[each.key].http_method}${aws_api_gateway_resource.this.path}"
+  source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${data.aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.this[each.key].http_method}${aws_api_gateway_resource.this.path}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,12 @@ variable "security_groups" {
   default = []
 }
 
+variable "vpc_networked" {
+  description = "If the lambda function should be deployed in a VPC."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
   description = "The VPC ID to deploy the lambda function in. If this value is null, the lambda function will be deployed outside of a VPC."
   type        = string


### PR DESCRIPTION
Upgraded the Lambda module source to v2.1.4 and introduced the vpc_networked variable to control VPC deployment of the Lambda function. Also fixed the region reference in the Lambda permission source_arn.