### PR TITLE
Update lambda module to v2.1.5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.1.4"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.1.5"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"


### PR DESCRIPTION
Bump the terraform-aws-lambda module source from v2.1.4 to v2.1.5 to include the latest updates and fixes.