### PR TITLE
Update lambda module version and remove main_filename variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.1.5"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.2.0"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"
@@ -10,7 +10,6 @@ module "lambda" {
   enable_tracing            = var.enable_tracing
   timeout                   = var.timeout
   additional_iam_statements = var.additional_iam_statements
-  main_filename             = var.main_filename
   security_groups           = var.security_groups
   vpc_id                    = var.vpc_id
   tags                      = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -57,12 +57,6 @@ variable "handler" {
   default     = null
 }
 
-variable "main_filename" {
-  type        = string
-  description = "Main filename of the lambda function (only needed for go Lambda functions)"
-  default     = "main.go"
-}
-
 variable "environment_variables" {
   description = "Environment variables used by the lambda function"
   type        = map(string)


### PR DESCRIPTION
Upgraded the lambda module source to v2.2.0 and removed the unused main_filename variable from both main.tf and variables.tf, reflecting changes in the module's requirements.