### PR TITLE
Add vpc_dualstack variable for Lambda module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.2.1"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.2.2"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"
@@ -15,6 +15,7 @@ module "lambda" {
   tags                      = var.tags
   go_build_tags             = var.go_build_tags
   vpc_networked             = var.vpc_networked
+  vpc_dualstack            = var.vpc_dualstack
 }
 
 resource "aws_api_gateway_resource" "this" {

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "lambda" {
   tags                      = var.tags
   go_build_tags             = var.go_build_tags
   vpc_networked             = var.vpc_networked
-  vpc_dualstack            = var.vpc_dualstack
+  vpc_dualstack             = var.vpc_dualstack
 }
 
 resource "aws_api_gateway_resource" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,12 @@ variable "vpc_id" {
   default     = null
 }
 
+variable "vpc_dualstack" {
+  description = "Whether to deploy the lambda function in a dualstack VPC (IPv4 and IPv6). Only used if vpc_networked is true."
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)


### PR DESCRIPTION
Introduces a new 'vpc_dualstack' variable to control dualstack (IPv4 and IPv6) deployment for the Lambda function when VPC networking is enabled. Updates the Lambda module source to version v2.2.2 to support this feature.