### PR TITLE
Refactor API Gateway resource creation logic

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,18 +1,11 @@
 locals {
-  # Determine if we should create a new API Gateway resource
-  # If existing_resource_id is provided, we'll use that existing resource
-  # If existing_resource_path is provided (legacy), we'll look it up
-  # Otherwise, create a new resource
-  should_create_resource = var.existing_resource_id == null
+  # Use the explicit boolean flag
+  should_create_resource = var.create_resource
 
   # Determine the parent resource ID
   parent_resource_id = var.parent_id == null ? data.aws_api_gateway_rest_api.api.root_resource_id : var.parent_id
 
-  # Determine the target resource ID (the resource where methods will be attached)
-  # Priority: existing_resource_id > newly created resource > legacy path lookup
-  target_resource_id = (
-    var.existing_resource_id != null ? var.existing_resource_id :
-    local.should_create_resource ? aws_api_gateway_resource.this[0].id :
-    var.existing_resource_id
-  )
+  # Determine the target resource ID
+  # If not creating, use the provided ID; otherwise use the created resource
+  target_resource_id = var.create_resource ? aws_api_gateway_resource.this[0].id : var.existing_resource_id
 }

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,6 @@ resource "aws_lambda_permission" "this" {
   function_name = module.lambda.function_name
   principal     = "apigateway.amazonaws.com"
 
-  # Build the source ARN using the resource ID directly
+  # Use wildcard for path since we don't track it when using existing_resource_id
   source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${data.aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.this[each.key].http_method}/*"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -177,8 +177,14 @@ variable "go_build_tags" {
   default     = []
 }
 
+variable "create_resource" {
+  description = "Whether to create a new API Gateway resource. Set to false when using existing_resource_id."
+  type        = bool
+  default     = true
+}
+
 variable "existing_resource_id" {
-  description = "ID of an existing API Gateway resource to attach methods to. If provided, no new resource will be created and existing_resource_path will be ignored."
+  description = "ID of an existing API Gateway resource to attach methods to. Only used when create_resource is false."
   type        = string
   default     = null
 }


### PR DESCRIPTION
Introduces a new 'create_resource' boolean variable to explicitly control whether a new API Gateway resource should be created. Updates local logic and variable descriptions to use this flag instead of inferring from 'existing_resource_id'. Adjusts Lambda permission source ARN to use a wildcard path when reusing an existing resource.