### PR TITLE
Refactor API Gateway to use api_id instead of api_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | github.com/FPGSchiba/terraform-aws-lambda | v2.2.3 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | github.com/FPGSchiba/terraform-aws-lambda | v2.2.4 |
 
 ## Resources
 
@@ -33,7 +33,6 @@
 | [aws_api_gateway_method_response.this_500](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_method_response) | resource |
 | [aws_api_gateway_resource.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_resource) | resource |
 | [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
-| [aws_api_gateway_rest_api.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/api_gateway_rest_api) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -42,7 +41,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_iam_statements"></a> [additional\_iam\_statements](#input\_additional\_iam\_statements) | Additional permissions added to the lambda function | <pre>list(object({<br/>    actions   = list(string)<br/>    resources = list(string)<br/>  }))</pre> | `[]` | no |
-| <a name="input_api_name"></a> [api\_name](#input\_api\_name) | A REST API Gateway name used to deploy all methods and stages on. | `string` | n/a | yes |
+| <a name="input_api_id"></a> [api\_id](#input\_api\_id) | The API Gateway REST API ID where the microservice will be deployed. | `string` | n/a | yes |
 | <a name="input_authorization_type"></a> [authorization\_type](#input\_authorization\_type) | The type of Authorization used on this microservice. ('NONE' or 'COGNITO\_USER\_POOLS') | `string` | `"NONE"` | no |
 | <a name="input_authorizer_id"></a> [authorizer\_id](#input\_authorizer\_id) | The Authorizer ID for cognito\_user\_pools. (Only Used if: authorization\_type == 'COGNITO\_USER\_POOLS') | `string` | `null` | no |
 | <a name="input_code_dir"></a> [code\_dir](#input\_code\_dir) | The path to the code to run the lambda function. | `string` | n/a | yes |

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,3 @@
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
-
-data "aws_api_gateway_rest_api" "api" {
-  name = var.api_name
-}

--- a/locals.tf
+++ b/locals.tf
@@ -2,9 +2,6 @@ locals {
   # Use the explicit boolean flag
   should_create_resource = var.create_resource
 
-  # Determine the parent resource ID
-  parent_resource_id = var.parent_id == null ? data.aws_api_gateway_rest_api.api.root_resource_id : var.parent_id
-
   # Determine the target resource ID
   # If not creating, use the provided ID; otherwise use the created resource
   target_resource_id = var.create_resource ? aws_api_gateway_resource.this[0].id : var.existing_resource_id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.2.3"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.2.4"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"
@@ -22,8 +22,9 @@ module "lambda" {
 # Create the API resource only when not binding to an existing resource
 resource "aws_api_gateway_resource" "this" {
   count       = local.should_create_resource ? 1 : 0
-  rest_api_id = data.aws_api_gateway_rest_api.api.id
-  parent_id   = local.parent_resource_id
+
+  rest_api_id = var.api_id
+  parent_id   = var.parent_id
   path_part   = var.path_name
 }
 
@@ -31,7 +32,7 @@ resource "aws_api_gateway_resource" "this" {
 resource "aws_api_gateway_method" "options" {
   count = var.cors_enabled ? 1 : 0
 
-  rest_api_id   = data.aws_api_gateway_rest_api.api.id
+  rest_api_id   = var.api_id
   resource_id   = local.target_resource_id
   http_method   = "OPTIONS"
   authorization = "NONE"
@@ -40,7 +41,7 @@ resource "aws_api_gateway_method" "options" {
 resource "aws_api_gateway_method_response" "options_200" {
   count = var.cors_enabled ? 1 : 0
 
-  rest_api_id = data.aws_api_gateway_rest_api.api.id
+  rest_api_id = var.api_id
   resource_id = local.target_resource_id
   http_method = aws_api_gateway_method.options[0].http_method
   status_code = 200
@@ -57,7 +58,7 @@ resource "aws_api_gateway_method_response" "options_200" {
 resource "aws_api_gateway_integration" "options" {
   count = var.cors_enabled ? 1 : 0
 
-  rest_api_id = data.aws_api_gateway_rest_api.api.id
+  rest_api_id = var.api_id
   resource_id = local.target_resource_id
   http_method = aws_api_gateway_method.options[0].http_method
   type        = "MOCK"
@@ -69,7 +70,7 @@ resource "aws_api_gateway_integration" "options" {
 resource "aws_api_gateway_integration_response" "options" {
   count = var.cors_enabled ? 1 : 0
 
-  rest_api_id = data.aws_api_gateway_rest_api.api.id
+  rest_api_id = var.api_id
   resource_id = local.target_resource_id
   http_method = aws_api_gateway_method.options[0].http_method
   status_code = aws_api_gateway_method_response.options_200[0].status_code
@@ -84,7 +85,7 @@ resource "aws_api_gateway_integration_response" "options" {
 resource "aws_api_gateway_method" "this" {
   for_each = toset(var.http_methods)
 
-  rest_api_id          = data.aws_api_gateway_rest_api.api.id
+  rest_api_id          = var.api_id
   resource_id          = local.target_resource_id
   http_method          = each.value
   authorization        = var.authorization_type
@@ -95,7 +96,7 @@ resource "aws_api_gateway_method" "this" {
 resource "aws_api_gateway_integration" "this" {
   for_each = toset(var.http_methods)
 
-  rest_api_id             = data.aws_api_gateway_rest_api.api.id
+  rest_api_id             = var.api_id
   resource_id             = local.target_resource_id
   http_method             = aws_api_gateway_method.this[each.key].http_method
   integration_http_method = "POST"
@@ -107,7 +108,7 @@ resource "aws_api_gateway_integration" "this" {
 resource "aws_api_gateway_method_response" "this_200" {
   for_each = toset(var.http_methods)
 
-  rest_api_id = data.aws_api_gateway_rest_api.api.id
+  rest_api_id = var.api_id
   resource_id = local.target_resource_id
   http_method = each.value
   status_code = 200
@@ -123,7 +124,7 @@ resource "aws_api_gateway_method_response" "this_200" {
 resource "aws_api_gateway_method_response" "this_500" {
   for_each = toset(var.http_methods)
 
-  rest_api_id = data.aws_api_gateway_rest_api.api.id
+  rest_api_id = var.api_id
   resource_id = local.target_resource_id
   http_method = each.value
   status_code = 500
@@ -146,5 +147,5 @@ resource "aws_lambda_permission" "this" {
   principal     = "apigateway.amazonaws.com"
 
   # Use wildcard for path since we don't track it when using existing_resource_id
-  source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${data.aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.this[each.key].http_method}/*"
+  source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/${aws_api_gateway_method.this[each.key].http_method}/*"
 }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "lambda" {
 
 # Create the API resource only when not binding to an existing resource
 resource "aws_api_gateway_resource" "this" {
-  count       = local.should_create_resource ? 1 : 0
+  count = local.should_create_resource ? 1 : 0
 
   rest_api_id = var.api_id
   parent_id   = var.parent_id

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -41,10 +41,11 @@ resource "aws_api_gateway_rest_api" "api" {
 
 module "microservice" {
   source       = "../../"
-  api_name     = aws_api_gateway_rest_api.api.name
+  api_id       = aws_api_gateway_rest_api.api.id
+  parent_id    = aws_api_gateway_rest_api.api.root_resource_id
   code_dir     = var.code_dir
   cors_enabled = var.cors_enabled
-  http_methods  = ["GET"]
+  http_methods = ["GET"]
   path_name    = var.path_name
   prefix       = var.prefix
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
-variable "api_name" {
-  description = "A REST API Gateway name used to deploy all methods and stages on."
+variable "api_id" {
+  description = "The API Gateway REST API ID where the microservice will be deployed."
   type        = string
 }
 


### PR DESCRIPTION
Replaces usage of api_name and aws_api_gateway_rest_api data source with direct api_id and parent_id variables for improved flexibility and compatibility. Updates module input, resource references, and documentation accordingly.