### PR TITLE
Update lambda module to v2.3.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.3.0"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.3.1"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"


### PR DESCRIPTION
Bumped the terraform-aws-lambda module source reference from v2.3.0 to v2.3.1 to incorporate the latest changes and improvements.