### PR TITLE
Update lambda module to v2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | github.com/FPGSchiba/terraform-aws-lambda | v2.3.2 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | github.com/FPGSchiba/terraform-aws-lambda | v2.3.3 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.3.2"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.3.3"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"


### PR DESCRIPTION
Bump the terraform-aws-lambda module version from v2.3.2 to v2.3.3 in both README and main.tf for improved features or bug fixes.