### PR TITLE
Add create_options_method variable to decouple OPTIONS creation from …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_api_gateway_resource" "this" {
 
 # CORS: OPTIONS method
 resource "aws_api_gateway_method" "options" {
-  count = var.cors_enabled ? 1 : 0
+  count = var.cors_enabled && var.create_options_method ? 1 : 0
 
   rest_api_id   = var.api_id
   resource_id   = local.target_resource_id
@@ -44,7 +44,7 @@ resource "aws_api_gateway_method" "options" {
 }
 
 resource "aws_api_gateway_method_response" "options_200" {
-  count = var.cors_enabled ? 1 : 0
+  count = var.cors_enabled && var.create_options_method ? 1 : 0
 
   rest_api_id = var.api_id
   resource_id = local.target_resource_id
@@ -61,7 +61,7 @@ resource "aws_api_gateway_method_response" "options_200" {
 }
 
 resource "aws_api_gateway_integration" "options" {
-  count = var.cors_enabled ? 1 : 0
+  count = var.cors_enabled && var.create_options_method ? 1 : 0
 
   rest_api_id = var.api_id
   resource_id = local.target_resource_id
@@ -73,7 +73,7 @@ resource "aws_api_gateway_integration" "options" {
 }
 
 resource "aws_api_gateway_integration_response" "options" {
-  count = var.cors_enabled ? 1 : 0
+  count = var.cors_enabled && var.create_options_method ? 1 : 0
 
   rest_api_id = var.api_id
   resource_id = local.target_resource_id

--- a/variables.tf
+++ b/variables.tf
@@ -235,3 +235,9 @@ variable "existing_resource_id" {
   type        = string
   default     = null
 }
+
+variable "create_options_method" {
+  description = "Whether to create the OPTIONS method for CORS preflight on this resource. Set to false when another module sharing the same resource already creates it."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
…cors_enabled

Introduces a new boolean variable `create_options_method` (default: true) so that modules sharing the same API Gateway resource can set it to false to avoid the ConflictException caused by multiple modules trying to create the same OPTIONS method.