### PR TITLE
chore: Bump lambda module to v2.4.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.4.0"
+  source = "github.com/FPGSchiba/terraform-aws-lambda?ref=v2.4.1"
 
   code_dir                  = var.code_dir
   name                      = "${var.prefix}-${var.name_overwrite == null ? var.path_name : var.name_overwrite}"


### PR DESCRIPTION
Update Terraform module source in main.tf from github.com/FPGSchiba/terraform-aws-lambda?ref=v2.4.0 to ?ref=v2.4.1 to pick up the v2.4.1 upstream fixes and improvements.